### PR TITLE
Edit post-finalization note

### DIFF
--- a/srfi-97.html
+++ b/srfi-97.html
@@ -52,8 +52,8 @@ the list.  You can access previous messages via
 <LI>Revised: <a href="http://srfi.schemers.org/srfi-97/srfi-97-1.2.html">2008/07/22</a></LI>
 <LI>Draft extended: 2008/07/22 - 2008/08/22</LI>
 <LI>Revised: <a href="http://srfi.schemers.org/srfi-97/srfi-97-1.3.html">2008/12/22</a></LI>
-<LI>Post-finalization note (added 2020/12/29):<br>
-  The standardized library names from this SRFI are now kept in the <code>library-name</code> attribute in the SRFI database file at <a class="eponymous" href="https://github.com/scheme-requests-for-implementation/srfi-common/blob/master/admin/srfi-data.scm">https://github.com/scheme-requests-for-implementation/srfi-common/blob/master/admin/srfi-data.scm</a>.</LI>
+<LI><b>Post-finalization note</b> (added 2019/12/29):<br>
+  The standardized library names from this SRFI, as well as the library names of newer SRFIs, are now kept in the <code>library-name</code> attribute of the SRFI database file at <a class="eponymous" href="https://github.com/scheme-requests-for-implementation/srfi-common/blob/master/admin/srfi-data.scm">https://github.com/scheme-requests-for-implementation/srfi-common/blob/master/admin/srfi-data.scm</a>.</LI>
 </UL>
 
 <h1>Table of contents</h1>


### PR DESCRIPTION
- Fix year in date.
- Clarify that newer SRFIs are also covered by the database.